### PR TITLE
Ttl fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The library is only suitable for educational references, and should not be used 
 
 ## API
 
-## Creation
+### Creation
 `zookeeper-node-shared-lock` returns a factory function that creates a lock service. The
 function expects a set of configuration options. Once the service is created, you may subscribe to the `ready` event. Once the `ready` event is fired, you may begin locking/unlocking resources.
 
@@ -15,6 +15,8 @@ The configuration parameters includes the following:
  - `host` - The hostname or IP of the zookeeper service.
  - `port` - The port number of zookeeper service.
  - `resourceName` - The name of the resource. Internally, this will be used as the parent ephemeral znode that holds all the child nodes.
+ - `maxRetryCount` - The maximum number of times the lock will retry after request timeout. By default, this value is 0, which implies we will wait indefinitely for this resource.
+ - `initialRetryWaitMs` - The amount of time to wait after initial failure. As failures accumulates, the retry wait will increase using the [binary exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff) algorithm. This value has no effect if `maxRetryCount` is 0.
 
 #### Sample
 
@@ -37,19 +39,25 @@ lockService.events.on('ready', () => {
 });
 ```
 
-## lock(resourceId, ttl, [cb])
+### lock(resourceId, ttl, [cb])
 
 `lock` acquires a resource asynchronously. The `resourceId` is the shared resource to lock. If the shared resource is acquired, or failed to be acquired, the `cb(err, acquiredResource)` will be invoked.
 
 The return `acquiredResource` argument is used to `unlock` the acquired resource.
 
-If `ttl` (in milliseconds) is provided, the lock service will retry up to TTL before giving up. The retry algorithm is [binary exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff).
+If `ttl` (in milliseconds) is provided, the lock service will automatically release the lock upon TTL expiration. User may subscribe to the `ttlExpired` event for this notification.
 
-If `ttl` is 0 (default), lock service will wait indefinitely until the resource is acquired. There is no retry invoked since a permanent watch is used to monitor the resource.
+If `ttl` is 0 (default), the acquired lock resource will be held indefinitely.
 
-## unlock(acquiredResource, [cb])
+### unlock(acquiredResource, [cb])
 
 `unlock` releases a resource asynchronously. The `acquiredResource` is the acquired resource returned from `lock`.
+
+
+## Events
+
+- `ready` - fired when Lock Service is ready.
+- `ttlExpired` - fired with `function (resourceId)` if a resource is being forcefully released.
 
 ## ZooKeeper Lock Recipe
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ If `ttl` is 0 (default), the acquired lock resource will be held indefinitely.
 
 - `ready` - fired when Lock Service is ready.
 - `ttlExpired` - fired with `function (resourceId)` if a resource is being forcefully released.
+- `disconnected` - fired when we lost connection to Zookeeper
 
 ## ZooKeeper Lock Recipe
 

--- a/lib/lock-protocol.js
+++ b/lib/lock-protocol.js
@@ -4,16 +4,21 @@ var zookeeper = require('node-zookeeper-client');
 const debug = require('debug')('lock-service:debug');
 const error = require('debug')('lock-service:error');
 
-// Each TTL tick is 100ms. This is the multiplier used to map collision collisionCount
-// to delay in milliseconds.
-const TTL_TICK = 100;
-
 const m = {};
 
 function lockAcquired(ctx) {
-  let acquiredPath = `${ctx.resourceName}/${ctx.seqZnode}`;
-  debug('lock acquired', acquiredPath);
-  ctx.cb(null, acquiredPath);
+  ctx.acquiredResource = `${ctx.resourceName}/${ctx.seqZnode}`;
+  let cb = ctx.cb;
+  delete ctx.cb;
+  if (ctx.ttl) {
+    setTimeout(() => {
+      error('lock held time exceeds TTL, force releasing lock', ctx.acquiredResource);
+      ctx.events.emit('ttlExpired', ctx.resourceId);
+      m.unlock(ctx);
+    }, ctx.ttl);
+  }
+  debug('lock acquired', ctx.acquiredResource);
+  cb(null, ctx);
 }
 
 function lockFailed(ctx, err) {
@@ -58,8 +63,9 @@ m.lock = (ctx) => {
 };
 
 m.unlock = (ctx) => {
+  ctx.cb = ctx.cb || function() {};
   if (!ctx.acquiredResource) {
-    return setImmediate(ctx.cb, 'resource can not be empty');
+    return setImmediate(ctx.cb);
   }
   debug('removing', ctx.acquiredResource);
   ctx.client.remove(ctx.acquiredResource, -1, (err) => {
@@ -68,6 +74,7 @@ m.unlock = (ctx) => {
       return ctx.cb('unable to unlock resource', ctx.acquiredResource);
     }
     debug('removed', ctx.acquiredResource);
+    delete ctx.acquiredResource;
     return ctx.cb();
   });
 };
@@ -148,11 +155,14 @@ function exists(ctx) {
             );
           }
 
-          let maxDelay = Math.pow(2, ctx.collisionCount) * TTL_TICK;
+          let maxDelay = Math.pow(2, ctx.collisionCount) * ctx.initialRetryWaitMs;
+          maxDelay = Math.min(maxDelay, ctx.initialRetryWaitMs * 10);
 
           let nextDelay = Math.floor((Math.random() * maxDelay));
 
-          debug('Lock is still not available, retrying in', nextDelay);
+          debug(
+            `Lock is still not available, retrying #${ctx.collisionCount} in ${nextDelay}`
+          );
 
           setTimeout(() => {
             ++ctx.collisionCount;

--- a/lib/lock-protocol.js
+++ b/lib/lock-protocol.js
@@ -114,7 +114,7 @@ function exists(ctx) {
   // If there is no TTL, then we can use a watch function to wait permanantly
   // for the next lowest node to be freed. Otherwise, we will poll with a
   // double-backoff timer.
-  if (!ctx.ttl) {
+  if (!ctx.maxRetryCount) {
     watchFunc = () => {
       return getChildren(ctx);
     };
@@ -135,17 +135,17 @@ function exists(ctx) {
 
       if (stat) {
 
-        // If lock owner uses TTL option, track the elapse time and calculate
-        // the next TTL check. This implementation uses the binary exponential
+        // If lock owner has maxRetryCount option, track the retry count and calculate
+        // the next retry timer. This implementation uses the binary exponential
         // backoff algorithm based on collision count.
         // https://en.wikipedia.org/wiki/Exponential_backoff
-        if (ctx.ttl) {
+        if (ctx.maxRetryCount) {
           ctx.collisionCount = ctx.collisionCount || 0;
-          ctx.totalElapsedTime = ctx.totalElapsedTime || 0;
-          if (ctx.totalElapsedTime > ctx.ttl) {
-            debug('Lock failed, ttl timed out', ctx.totalElapsedTime);
+          if (ctx.collisionCount > ctx.maxRetryCount) {
+            debug('Lock failed, retry count limit reached - ', ctx.collisionCount);
             return lockFailed(ctx,
-              `'Lock failed, ttl timed out - ${ctx.totalElapsedTime}`);
+              `Lock failed, retry count limit reached - ${ctx.collisionCount}`
+            );
           }
 
           let maxDelay = Math.pow(2, ctx.collisionCount) * TTL_TICK;
@@ -156,7 +156,6 @@ function exists(ctx) {
 
           setTimeout(() => {
             ++ctx.collisionCount;
-            ctx.totalElapsedTime += nextDelay;
             return getChildren(ctx);
           }, nextDelay);
         }

--- a/lib/lock-service.js
+++ b/lib/lock-service.js
@@ -13,12 +13,13 @@ function createLockService(opt) {
   opt.port = opt.port || '2181';
   opt.resourceName = opt.resourceName || '/__lock_service_resource__';
   opt.maxRetryCount = opt.maxRetryCount || 0;
-  opt.initialRetryMs = opt.initialRetryMs || 100;
+  opt.initialRetryWaitMs = opt.initialRetryWaitMs || 100;
 
   const zkClient = zookeeper.createClient(`${opt.host}:${opt.port}`);
   let lockService = {};
   lockService.events = new EventEmitter();
 
+  // See README.md
   lockService.lock = (resourceId, ttl, cb) => {
     cb = cb || function() {};
     let ctx = {
@@ -26,30 +27,35 @@ function createLockService(opt) {
       client: zkClient,
       ttl,
       maxRetryCount: lockService.maxRetryCount,
-      initialRetryMs: lockService.initialRetryMs,
+      initialRetryWaitMs: lockService.initialRetryWaitMs,
       resourceName: opt.resourceName,
-      resourceId
+      resourceId,
+      events: lockService.events
     };
     lockProtocol.lock(ctx);
   };
 
-  lockService.unlock = (acquiredResource, cb) => {
+  // See README.md
+  lockService.unlock = (lockCtx, cb) => {
     cb = cb || function() {};
-    let ctx = {
-      cb,
-      client: zkClient,
-      resourceName: opt.resourceName,
-      acquiredResource
-    };
-    lockProtocol.unlock(ctx);
+    if (!lockCtx) {
+      return setImmediate(cb, 'lock context must be provided');
+    }
+    lockCtx.cb = cb;
+    lockProtocol.unlock(lockCtx);
   };
 
-  lockService.backoff = (maxRetryCount, initialRetryMs) => {
+  // See README.md
+  lockService.backoff = (maxRetryCount, initialRetryWaitMs) => {
     lockService.maxRetryCount = maxRetryCount;
-    lockService.initialRetryMs = initialRetryMs;
+    lockService.initialRetryWaitMs = initialRetryWaitMs;
   };
-  lockService.backoff(opt.maxRetryCount, opt.initialRetryMs);
 
+  // Initialize the retry count and retry wait using the provided options.
+  lockService.backoff(opt.maxRetryCount, opt.initialRetryWaitMs);
+
+  // Connected to ZK on startup and initialize the default resource parent node.
+  // Once ZK is ready and the node is created, 'ready' event will be emitted.
   zkClient.once('connected', () => {
     debug('Connected to ZooKeeper.');
     zkClient.create(opt.resourceName, null, zookeeper.CreateMode.PERSISTENT,

--- a/lib/lock-service.js
+++ b/lib/lock-service.js
@@ -12,6 +12,8 @@ function createLockService(opt) {
   opt.host = opt.host || 'localhost';
   opt.port = opt.port || '2181';
   opt.resourceName = opt.resourceName || '/__lock_service_resource__';
+  opt.maxRetryCount = opt.maxRetryCount || 0;
+  opt.initialRetryMs = opt.initialRetryMs || 100;
 
   const zkClient = zookeeper.createClient(`${opt.host}:${opt.port}`);
   let lockService = {};
@@ -23,6 +25,8 @@ function createLockService(opt) {
       cb,
       client: zkClient,
       ttl,
+      maxRetryCount: lockService.maxRetryCount,
+      initialRetryMs: lockService.initialRetryMs,
       resourceName: opt.resourceName,
       resourceId
     };
@@ -40,21 +44,28 @@ function createLockService(opt) {
     lockProtocol.unlock(ctx);
   };
 
+  lockService.backoff = (maxRetryCount, initialRetryMs) => {
+    lockService.maxRetryCount = maxRetryCount;
+    lockService.initialRetryMs = initialRetryMs;
+  };
+  lockService.backoff(opt.maxRetryCount, opt.initialRetryMs);
+
   zkClient.once('connected', () => {
     debug('Connected to ZooKeeper.');
-    zkClient.create(opt.resourceName, null, zookeeper.CreateMode.PERSISTENT, (err) => {
-      if (err) {
-        if (err.getCode() !== zookeeper.Exception.NODE_EXISTS) {
-          error('Unable to create resource', opt.resourceName, err);
-          lockService.events.emit('error');
-          return;
-        } else {
-          debug('reusing existing resource', opt.resourceName);
+    zkClient.create(opt.resourceName, null, zookeeper.CreateMode.PERSISTENT,
+      (err) => {
+        if (err) {
+          if (err.getCode() !== zookeeper.Exception.NODE_EXISTS) {
+            error('Unable to create resource', opt.resourceName, err);
+            lockService.events.emit('error');
+            return;
+          } else {
+            debug('reusing existing resource', opt.resourceName);
+          }
         }
-      }
 
-      lockService.events.emit('ready');
-    });
+        lockService.events.emit('ready');
+      });
   });
 
   zkClient.once('connectedReadOnly', () => {

--- a/lib/lock-service.js
+++ b/lib/lock-service.js
@@ -6,29 +6,29 @@ const EventEmitter = require('events').EventEmitter;
 const debug = require('debug')('lock-service:debug');
 const error = require('debug')('lock-service:error');
 
-function createLockService(opt) {
-  opt = opt || {};
+function createLockService({
+  host = 'localhost',
+  port = '2181',
+  resourceName = '/__lock_service_resource__',
+  maxRetryCount = 0,
+  initialRetryWaitMs = 100
+} = {}) {
 
-  opt.host = opt.host || 'localhost';
-  opt.port = opt.port || '2181';
-  opt.resourceName = opt.resourceName || '/__lock_service_resource__';
-  opt.maxRetryCount = opt.maxRetryCount || 0;
-  opt.initialRetryWaitMs = opt.initialRetryWaitMs || 100;
-
-  const zkClient = zookeeper.createClient(`${opt.host}:${opt.port}`);
+  const zkClient = zookeeper.createClient(`${host}:${port}`);
   let lockService = {};
+
+  // Event emitter provides notification for lockService user.
   lockService.events = new EventEmitter();
 
   // See README.md
-  lockService.lock = (resourceId, ttl, cb) => {
-    cb = cb || function() {};
+  lockService.lock = (resourceId, ttl, cb = () => {}) => {
     let ctx = {
       cb,
       client: zkClient,
       ttl,
       maxRetryCount: lockService.maxRetryCount,
       initialRetryWaitMs: lockService.initialRetryWaitMs,
-      resourceName: opt.resourceName,
+      resourceName: resourceName,
       resourceId,
       events: lockService.events
     };
@@ -36,8 +36,7 @@ function createLockService(opt) {
   };
 
   // See README.md
-  lockService.unlock = (lockCtx, cb) => {
-    cb = cb || function() {};
+  lockService.unlock = (lockCtx, cb = () => {}) => {
     if (!lockCtx) {
       return setImmediate(cb, 'lock context must be provided');
     }
@@ -52,21 +51,21 @@ function createLockService(opt) {
   };
 
   // Initialize the retry count and retry wait using the provided options.
-  lockService.backoff(opt.maxRetryCount, opt.initialRetryWaitMs);
+  lockService.backoff(maxRetryCount, initialRetryWaitMs);
 
   // Connected to ZK on startup and initialize the default resource parent node.
   // Once ZK is ready and the node is created, 'ready' event will be emitted.
   zkClient.once('connected', () => {
     debug('Connected to ZooKeeper.');
-    zkClient.create(opt.resourceName, null, zookeeper.CreateMode.PERSISTENT,
+    zkClient.create(resourceName, null, zookeeper.CreateMode.PERSISTENT,
       (err) => {
         if (err) {
           if (err.getCode() !== zookeeper.Exception.NODE_EXISTS) {
-            error('Unable to create resource', opt.resourceName, err);
+            error('Unable to create resource', resourceName, err);
             lockService.events.emit('error');
             return;
           } else {
-            debug('reusing existing resource', opt.resourceName);
+            debug('reusing existing resource', resourceName);
           }
         }
 
@@ -76,15 +75,19 @@ function createLockService(opt) {
 
   zkClient.once('connectedReadOnly', () => {
     error('server is read-only');
+    lockService.events.emit('connectedReadOnly');
   });
   zkClient.once('disconnected', () => {
     error('server connection has been disconnected');
+    lockService.events.emit('disconnected');
   });
   zkClient.once('expired', () => {
     error('server connection has expired');
+    lockService.events.emit('expired');
   });
   zkClient.once('authenticationFailed', () => {
     error('server authentication failed');
+    lockService.events.emit('authenticationFailed');
   });
 
   zkClient.connect();

--- a/test/lock-service.test.js
+++ b/test/lock-service.test.js
@@ -4,7 +4,7 @@ const createLockService = require('../lib/lock-service');
 const RESOURCE_ID = 'myresource';
 const expect = require('expect');
 
-describe('', function() {
+describe('Lock Service test suite', function() {
 
   describe('Simple Lock Unlock Test', function() {
 
@@ -36,12 +36,35 @@ describe('', function() {
     });
   });
 
+  describe('Simple Lock with Unlock TTL Test', function() {
+
+    let lockService;
+    it('create lock service', function(done) {
+      let opt = {};
+      lockService = createLockService(opt);
+
+      lockService.events.on('ready', () => {
+        done();
+      });
+    });
+
+    it('lock a resource and wait for TTL expiration', function(done) {
+      lockService.events.on('ttlExpired', (resourceId) => {
+        expect(resourceId).toBeTruthy();
+        done();
+      });
+      lockService.lock(RESOURCE_ID, 500, (err, lockCtx) => {
+        expect(err).toBeFalsy();
+        expect(lockCtx).toBeTruthy();
+      });
+    });
+  });
+
   function makeTwoLockTest(opt) {
     return function() {
       let lockService;
       let acquiredResource;
       it('create lock service', function(done) {
-        let opt = {};
         lockService = createLockService(opt);
 
         lockService.events.on('ready', () => {
@@ -50,7 +73,7 @@ describe('', function() {
       });
 
       it('lock a resource', function(done) {
-        lockService.lock(RESOURCE_ID, opt.ttl, (err, resource) => {
+        lockService.lock(RESOURCE_ID, 0, (err, resource) => {
           acquiredResource = resource;
           done();
         });
@@ -59,7 +82,7 @@ describe('', function() {
       it('lock contention, need to wait 2 sec before acquiring', function(
         done) {
         this.timeout(10000);
-        lockService.lock(RESOURCE_ID, opt.ttl, (err, resource) => {
+        lockService.lock(RESOURCE_ID, 0, (err, resource) => {
           acquiredResource = resource;
           done();
         });
@@ -80,19 +103,22 @@ describe('', function() {
     };
   }
 
-  describe('Two-lock Test with infinite wait', makeTwoLockTest({
-    ttl: 0
+  describe('Two-lock Test with watch', makeTwoLockTest({
+    maxRetryCount: 0
   }));
 
-  describe('Two-lock Test with TTL', makeTwoLockTest({
-    ttl: 5000
-  }));
+  describe('Two-lock Test with periodic poll',
+    makeTwoLockTest({
+      maxRetryCount: 5000
+    }));
 
-  describe('Two-lock Test with TTL failure', function() {
+  describe('Two-lock Test with retry count failure', function() {
     let lockService;
     let acquiredResource;
     it('create lock service', function(done) {
-      let opt = {};
+      let opt = {
+        maxRetryCount: 1
+      };
       lockService = createLockService(opt);
 
       lockService.events.on('ready', () => {
@@ -101,7 +127,7 @@ describe('', function() {
     });
 
     it('lock a resource', function(done) {
-      lockService.lock(RESOURCE_ID, 500, (err, resource) => {
+      lockService.lock(RESOURCE_ID, 0, (err, resource) => {
         acquiredResource = resource;
         done();
       });
@@ -110,7 +136,7 @@ describe('', function() {
     it('lock contention, need to wait 2 sec before acquiring', function(
       done) {
       this.timeout(4000);
-      lockService.lock(RESOURCE_ID, 500, (err) => {
+      lockService.lock(RESOURCE_ID, 0, (err) => {
         expect(err).toBeTruthy();
         done();
       });
@@ -124,12 +150,12 @@ describe('', function() {
     });
   });
 
-  function makeNLockTest(opt) {
+  // N-Contenders for a single resource, and lock hold must be released manually.
+  function makeNLockTestWithManualTtl(opt) {
     return function() {
 
       let lockService;
       it('create lock service', function(done) {
-        let opt = {};
         lockService = createLockService(opt);
 
         lockService.events.on('ready', () => {
@@ -138,10 +164,10 @@ describe('', function() {
       });
 
       it('lock a resource', function(done) {
-        this.timeout(opt.lockHoldTimeMs * opt.numContention * 10);
+        this.timeout(opt.manualTtl * opt.numContention * 10);
         let acquired = 0;
         for (let i = 0; i < opt.numContention; ++i) {
-          lockService.lock(RESOURCE_ID, opt.ttl, (err, resource) => {
+          lockService.lock(RESOURCE_ID, 0, (err, resource) => {
             expect(err).toBeFalsy();
             ++acquired;
             setTimeout(() => {
@@ -151,24 +177,71 @@ describe('', function() {
                   done();
                 }
               });
-            }, opt.lockHoldTimeMs);
+            }, opt.manualTtl);
           });
         }
       });
     };
   }
 
+  // N-Contenders for a single resource, and lock hold will be released automatically
+  function makeNLockTestWithAutoTtl(opt) {
+    return function() {
 
-  describe('N-lock Test', makeNLockTest({
-    lockHoldTimeMs: 500,
-    numContention: 50,
-    ttl: 0
-  }));
+      let lockService;
+      it('create lock service', function(done) {
+        lockService = createLockService(opt);
 
-  describe('N-lock Test with TTL', makeNLockTest({
-    lockHoldTimeMs: 500,
-    numContention: 5,
-    ttl: 100000000
-  }));
+        lockService.events.on('ready', () => {
+          done();
+        });
+      });
 
+      it('lock a resource and wait for TTL expiration', function(done) {
+        this.timeout(opt.ttl * opt.numContention * 10);
+        let completed = 0;
+        lockService.events.on('ttlExpired', (resourceId) => {
+          expect(resourceId).toBeTruthy();
+          ++completed;
+          if (completed === opt.numContention) {
+            done();
+          }
+        });
+        for (let i = 0; i < opt.numContention; ++i) {
+          lockService.lock(RESOURCE_ID, opt.ttl, (err, lockCtx) => {
+            expect(err).toBeFalsy();
+            expect(lockCtx).toBeTruthy();
+          });
+        }
+      });
+    };
+  }
+
+  describe('N-lock Test with manual TTL and watch',
+    makeNLockTestWithManualTtl({
+      manualTtl: 500,
+      numContention: 50,
+      maxRetryCount: 0
+    }));
+
+  describe('N-lock Test with manual TTL and periodic poll',
+    makeNLockTestWithManualTtl({
+      manualTtl: 500,
+      numContention: 5,
+      maxRetryCount: 100000000
+    }));
+
+  describe('N-lock Test with auto TTL and watch',
+    makeNLockTestWithAutoTtl({
+      ttl: 500,
+      numContention: 50,
+      maxRetryCount: 0
+    }));
+
+  describe('N-lock Test with auto TTL and periodic poll',
+    makeNLockTestWithAutoTtl({
+      ttl: 500,
+      numContention: 5,
+      maxRetryCount: 100000000
+    }));
 });


### PR DESCRIPTION
v1.1.0

TTL is now defined as how long a resource owner may own a lock before it is automatically released.

Retry Count and Retry Wait is now moved into the `backoff` API.

Unit test is updated to stress these new changes. 
